### PR TITLE
define_association_to_avoid_excuition_sql

### DIFF
--- a/app/controllers/prototypes/tags_controller.rb
+++ b/app/controllers/prototypes/tags_controller.rb
@@ -5,6 +5,6 @@ class Prototypes::TagsController < ApplicationController
 
   def show
     @tag = ActsAsTaggableOn::Tag.find_by(name: params[:tag_name])
-    @prototypes = Prototype.tagged_with(@tag).order(likes_count: :desc)
+    @prototypes = Prototype.tagged_with(@tag).eager_load(:main_image, :user).order(likes_count: :desc)
   end
 end

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -3,7 +3,7 @@ class PrototypesController < ApplicationController
   before_action :set_new_comment, only: [:show, :update]
 
   def index
-    @prototypes = Prototype.all
+    @prototypes = Prototype.eager_load(:main_image, :user)
   end
 
   def new
@@ -26,7 +26,7 @@ class PrototypesController < ApplicationController
   end
 
   def edit
-    @main_image = @prototype.captured_images.main.first
+    @main_image = @prototype.main_image
     @sub_images = @prototype.set_sub_thumbnails
   end
 

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -4,6 +4,8 @@ class Prototype < ActiveRecord::Base
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
 
+  has_one :main_image, class_name: "CapturedImage"
+
   accepts_nested_attributes_for :captured_images, reject_if: :reject_sub_images, limit: 4
 
   acts_as_taggable

--- a/app/views/prototypes/_prototype.html.haml
+++ b/app/views/prototypes/_prototype.html.haml
@@ -1,6 +1,6 @@
 .col-sm-4.col-md-3.proto-content
   .thumbnail
-    = link_to image_tag(prototype.set_main_thumbnail), prototype_path(prototype)
+    = link_to image_tag(prototype.main_image.content), prototype_path(prototype)
     .caption
       %h3
         = prototype.title


### PR DESCRIPTION
# WHY
- prototypeの一覧を表示する際にenumを使用しており大量のsqlが発行されてしまっているため
# WHAT
- アソシエーションを定義してenumを使用するのを防ぎ、sqlの発行を防ぐ
